### PR TITLE
chore: IFTAS GitHub repository URL change

### DIFF
--- a/projects/iftas-apps.json
+++ b/projects/iftas-apps.json
@@ -8,15 +8,15 @@
     "branch":"develop"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/rfp",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/rfp",
     "branch":"master"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_finance",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_finance",
     "branch":"master"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_customization",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_customization",
     "branch":"master"
   },
   {

--- a/projects/iftas_uat-apps.json
+++ b/projects/iftas_uat-apps.json
@@ -8,15 +8,15 @@
     "branch":"develop"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/rfp",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/rfp",
     "branch":"master"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_finance",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_finance",
     "branch":"master"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_customization",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_customization",
     "branch":"develop"
   },
   {

--- a/projects/in_iftas-apps.json
+++ b/projects/in_iftas-apps.json
@@ -8,15 +8,15 @@
     "branch":"develop"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/rfp",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/rfp",
     "branch":"develop"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_finance",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_finance",
     "branch":"develop"
   },
   {
-    "url":"https://{{user}}:{{token}}@github.com/iftas-erpnext/iftas_customization",
+    "url":"https://{{user}}:{{token}}@github.com/IFTAS-ERP/iftas_customization",
     "branch":"develop"
   },
   {


### PR DESCRIPTION
Changing URL for apps to new github organisation:
https://github.com/IFTAS-ERP/

Repositories have a develop and master branch, preserved the branches used in environments.